### PR TITLE
fix: attributes may cross multi-lines

### DIFF
--- a/rss-feed@gnome-shell-extension.todevelopers.github.com/rexml.js
+++ b/rss-feed@gnome-shell-extension.todevelopers.github.com/rexml.js
@@ -147,7 +147,7 @@ function REXML(XML) {
 
 function ParseAttribute(str,Attribute) {
 	var str = str +  ">";
-	if (str.indexOf(Attribute + "='")>-1) var Attr = new RegExp(".*" + Attribute + "='([^']*)'.*>");
-	else if (str.indexOf(Attribute + '="')>-1) var Attr = new RegExp(".*" + Attribute + '="([^"]*)".*>');
-	return str.replace(Attr, "$1");
+	if (str.indexOf(Attribute + "='")>-1) var Attr = new RegExp("(.*\\n)*.*" + Attribute + "='([^']*)'.*>");
+	else if (str.indexOf(Attribute + '="')>-1) var Attr = new RegExp("(.*\\n)*.*" + Attribute + '="([^"]*)".*>');
+	return str.replace(Attr, "$2");
 }


### PR DESCRIPTION
e.g.

```
<link rel="alternate" type="text/html"
      href="http://example.com">
```
